### PR TITLE
Define mask shape in configuration. Original shape unchanged

### DIFF
--- a/RPi/bin/data/config.xml
+++ b/RPi/bin/data/config.xml
@@ -21,4 +21,15 @@
     <LOCATIONID>1</LOCATIONID>
     <BRIGHTNESS>70</BRIGHTNESS>
     <CONTRAST>0</CONTRAST>
+    <MASKPOINTS>
+	<POINT x="95" y="0"/>
+	<POINT x="123" y="211"/>
+	<POINT x="228" y="220"/>
+	<POINT x="270" y="0"/>
+	<!-- Uncomment the points below to get rid of any masks -->
+	<!--POINT x="0" y="0"/>
+	<POINT x="320" y="0"/>
+	<POINT x="320" y="240"/>
+	<POINT x="0" y="240"/-->
+    </MASKPOINTS>
 </CONFIG>

--- a/RPi/src/ofApp.cpp
+++ b/RPi/src/ofApp.cpp
@@ -36,6 +36,17 @@ void ofApp::loadConfig()
         _lightenAmount = XML.getValue("CONFIG:LIGHTENAMOUNT",35);
         _contrast = XML.getValue("CONFIG:CONTRAST",0);
         _brightness = XML.getValue("CONFIG:BRIGHTNESS",0);
+        XML.pushTag("CONFIG:MASKPOINTS");
+        XML.pushTag("MASKPOINTS:POINT");
+        int nbPoints = XML.getNumTags("POINT");
+        for (int i = 0; i < nbPoints; i++) {
+            int x, y;
+            x = XML.getAttribute("POINT", "x", 0, i);
+            y = XML.getAttribute("POINT", "y", 0, i);
+            _maskPoints.push_back(cv::Point(x, y));
+        }
+        XML.popTag();
+        XML.popTag();
         cout << "Loaded Settings" << endl;
     }
     else {
@@ -46,19 +57,13 @@ void ofApp::loadConfig()
 //--------------------------------------------------------------
 void ofApp::makeMask()
 {
-    vector <cv::Point> maskright;
-    maskright.push_back(cv::Point(95,0));
-    maskright.push_back(cv::Point(123,211));
-    maskright.push_back(cv::Point(228,220));
-    maskright.push_back(cv::Point(270,0));
-    
     mask = cvCreateMat(240, 320, CV_8UC1);
     for(int i=0; i<mask.cols; i++)
         for(int j=0; j<mask.rows; j++)
             mask.at<uchar>(cv::Point(i,j)) = 0;
     
     vector<cv::Point> polyright;
-    approxPolyDP(maskright, polyright, 1.0, true);
+    approxPolyDP(_maskPoints, polyright, 1.0, true);
     
     fillConvexPoly(mask,&polyright[0],polyright.size(),255,8,0);
 }
@@ -73,8 +78,8 @@ void ofApp::setup()
     countInLatch = false;
     countOutLatch = false;
     
-    makeMask();
     loadConfig();
+    makeMask();
     
     startLine = ofPoint(0,_cameraHeight/2);
     endLine = ofPoint(_cameraWidth,_cameraHeight/2);

--- a/RPi/src/ofApp.h
+++ b/RPi/src/ofApp.h
@@ -14,7 +14,6 @@
 #include "ofxCvPiCam.h"
 #include "ofxXmlSettings.h"
 
-using namespace wng;
 using namespace ofxCv;
 using namespace cv;
 
@@ -83,6 +82,7 @@ public:
     int _lightenAmount;
     int _contrast;
     int _brightness;
+    vector <cv::Point> _maskPoints;
     
     string _locationID;
     string _secretKey;


### PR DESCRIPTION
Hi,

A quick change that abstract the Points definition of the mask shape into config.xml. Didn't want to recompile every time I changed the shape for my use case. It comes pre-configured with your shape as default.

Also slipped in there is the removal of `using namespace wng;` mentionned in issue #1.

If you are interested I can also do a pull request for code that uses ofxGifEncoder to export the first X seconds of capture. Although I assume you have one such solution already, used for your blog post - probably better than my own even.

Great piece of software by the way !
