### PR TITLE
Improved clarity in rpi.md

### DIFF
--- a/docs/rpi.md
+++ b/docs/rpi.md
@@ -1,58 +1,41 @@
-#Raspberry Pi
+# Raspberry Pi Setup 
 
+This guide is tested on RPI 1,2 & 3. 
 
-###How to setup the Raspberry Pi
+## Foundation 
 
-Download a Noobs Package from [here](https://www.raspberrypi.org/downloads/noobs/).
+* Download a Noobs Package from [here](https://www.raspberrypi.org/downloads/noobs/).
+* Install Jessie. And wait.
+* Once the sd card is ready and the system has rebooted.
+*   ``sudo raspi-config`` to open the Raspberry Pi Config screen. 
+ * Expand the filesytem and reboot.
 
-Install Jessie.
+## Install openSourceFrameworks
+[Build and compile oF](http://forum.openframeworks.cc/t/raspberry-pi-2-setup-guide/18690).
 
-And wait.
-
-Once the sd card is ready and the system has rebooted.
-
-open the Raspberry Pi Config screen
-
-````sudo raspi-config````
-
-and expand the filesytem and reboot.
-
+## Installing dependencis for Footfall 
 You will need a few extra packages to build the RPi application.
 
-Copy the getrepos.sh file and place it inside the addons folder of your openFrameworks folder. 
+* Copy the `getrepos.sh` [file's data](https://github.com/WatershedArts/Footfall/blob/master/getrepos.sh) and place it inside the addons folder of your openFrameworks folder. 
 
-Run the script by navigating to the addons folder and entering the following command into Terminal 
+  ```
+  cd ~/openFrameworks/addons
+  touch getrepos.sh && vim getrepos.sh
+  ```
+This opens up vim editor for editing getrepos.sh. Press <kbd>A</kbd> for Insert and paste the contents from the link. Press <kbd>ESC</kbd> then <kbd>SHIFT</kbd>+<kbd>:</kbd>. Type wq and then press enter to save the file. 
 
-`./getrepos.sh`. 
+* Run the script by:  `./getrepos.sh`. 
 
-This will pull down the required packages.
+This will pull down the required packages. Then ensure you have pulled the latest versions of the addons using the script above.
 
-Then ensure you have pulled the latest versions of the addons using the script above.
+* Please run the following.
 
-Please run the following.
+  ```
+  sudo apt-get update
+  sudo apt-get upgrade
+  sudo raspi-update
+  ```
+  
+* Enable Camera by `sudo raspi-config` and Reboot.
 
-`sudo apt-get update`
-
-`sudo apt-get upgrade`
-
-`sudo raspi-update`
-
-`sudo raspi-config`
-
-Enable Camera
-
-and Reboot.
-
-Test the camera is working. 
-
-```raspistill -o testimage.jpg```
-
-You will also need to update your Pi
-
-`sudo apt-get update`
-
-`sudo apt-get upgrade`
-
-`sudo raspi-update`
-
-Assuming you have [built and compiled oF](http://forum.openframeworks.cc/t/raspberry-pi-2-setup-guide/18690).
+* Test the camera is working by ``raspistill -o testimage.jpg``. Open testimage.jpg to check the output. 


### PR DESCRIPTION
Thought process behind some decisions. Fundamental reason is because most users tend to straight away move to docs without exploring about the project much so there are various painpoints that user might get stuck: 

* Users like me who are Raspberry Pi 3 have no clue whether it would work on our system or not. It works on my RPI3 and you guys have tested on RPI 1 & 2. Adding this disclaimer in the start assuages user. 
* User get's to know that he/she has to build opensourceFrameworks in the last. Most users tend not to read the entire guide in one go, generally they follow step by step. Therefore moved the step ahead. 
* Added links for `getrepos.sh` file. Since user has no idea that he/she has to use the getrepos.sh, provided the steps. The user could have cloned FootFall but he/she already does in the next steps therefore copying works for now. 
* Deleted repeated steps for update and upgrade. 
* Fixed whitespace error

Also `sudo raspi-update` doesn't work. I googled and there this is command called rpi-update.